### PR TITLE
fix: logger stream encoding

### DIFF
--- a/exporter/src/CTFAK.Core/Utils/Logger.cs
+++ b/exporter/src/CTFAK.Core/Utils/Logger.cs
@@ -19,7 +19,7 @@ namespace CTFAK.Utils
 		static Logger()
 		{
 			File.Delete("Latest.log");
-			_writer = new StreamWriter("Latest.log", false);
+			_writer = new StreamWriter("Latest.log", false, System.Text.Encoding.UTF8);
 			_writer.AutoFlush = true;
 		}
 


### PR DESCRIPTION
fix encoding problems whenever invalid characters are logged
<img width="1920" height="353" alt="{87FB3A54-2159-466D-9802-569981192DEA}" src="https://github.com/user-attachments/assets/88c76924-3dd5-4330-adfd-16c9b3a16c42" />
